### PR TITLE
Make AVX2 support optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 regex = "1.6.0"
-ahash = "=0.8.4"
+ahash = "0.8.11"
 hashbrown = "0.13"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rust implementation of quantum circuits optimization algorithms presented in the
 
 ### Usage
 [Install rust](https://www.rust-lang.org/tools/install) and run ```cargo +nightly run -r [OPTIONS] file.qc```
-where ```file.qc``` is any .qc file.
+where ```file.qc``` is any .qc file. If your machine supports AVX2, it can be enabled with ```RUSTFLAGS="-C target-cpu=native" cargo run -r [OPTIONS] file.qc```.
 
 ```[OPTIONS]``` are (case-insensitive and in no order):
 - ```BBMerge``` runs the BBMerge algorithm

--- a/src/bit_vector.rs
+++ b/src/bit_vector.rs
@@ -1,9 +1,103 @@
-use std::arch::x86_64::__m256i;
-use std::arch::x86_64::{_mm256_setzero_si256, _mm256_load_epi32, _mm256_extract_epi32, _mm256_xor_si256 as xor_256, _popcnt32, _mm256_and_si256 as and_256, _mm256_set1_epi32};
+// A wrapper type to enforce 32-byte alignment for SIMD loads
+#[repr(align(32))]
+struct BitLanes([i32; 8]);
+
+#[derive(Debug, Clone, Copy)]
+pub struct BitBlock {
+    #[cfg(target_feature = "avx2")]
+    inner: std::arch::x86_64::__m256i,
+
+    #[cfg(not(target_feature = "avx2"))]
+    inner: [i32; 8]
+}
+
+impl BitBlock {
+    #[cfg(target_feature = "avx2")]
+    fn constant(a: i32) -> Self {
+        BitBlock {
+            inner: unsafe { std::arch::x86_64::_mm256_set1_epi32(a) }
+        }
+    }
+
+    #[cfg(not(target_feature = "avx2"))]
+    fn constant(a: i32) -> Self {
+        BitBlock {
+            inner: [a; 8]
+        }
+    }
+
+    #[cfg(target_feature = "avx2")]
+    fn load(arr: &BitLanes) -> Self {
+        BitBlock {
+            // SAFETY: BitLanes is 32-byte aligned
+            inner: unsafe { std::arch::x86_64::_mm256_load_si256(arr.0.as_ptr() as *const _) }
+        }
+    }
+
+    #[cfg(not(target_feature = "avx2"))]
+    fn load(arr: &BitLanes) -> Self {
+        BitBlock {
+            inner: arr.0.clone()
+        }
+    }
+    
+    #[cfg(target_feature = "avx2")]
+    fn zero() -> Self {
+        BitBlock {
+            inner: unsafe { std::arch::x86_64::_mm256_setzero_si256() }
+        }
+    }
+
+    #[cfg(not(target_feature = "avx2"))]
+    fn zero() -> Self {
+        Self::constant(0)
+    }
+
+    #[cfg(target_feature = "avx2")]
+    fn extract(&self) -> [i32; 8] {
+        let mut arr = BitLanes([0; 8]);
+        // SAFETY: BitLanes is 32-byte aligned
+        unsafe { std::arch::x86_64::_mm256_store_si256(arr.0.as_mut_ptr() as *mut _, self.inner); }
+        arr.0
+    }
+
+    #[cfg(not(target_feature = "avx2"))]
+    fn extract(&self) -> [i32; 8] {
+        self.inner
+    }
+}
+
+impl std::ops::BitXorAssign for BitBlock {
+    #[cfg(target_feature = "avx2")]
+    fn bitxor_assign(&mut self, rhs: Self) {
+        self.inner = unsafe { std::arch::x86_64::_mm256_xor_si256(self.inner, rhs.inner) };
+    }
+
+    #[cfg(not(target_feature = "avx2"))]
+    fn bitxor_assign(&mut self, rhs: Self) {
+        for i in 0..8 {
+            self.inner[i] ^= rhs.inner[i];
+        }
+    }
+}
+
+impl std::ops::BitAndAssign for BitBlock {
+    #[cfg(target_feature = "avx2")]
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.inner = unsafe { std::arch::x86_64::_mm256_and_si256(self.inner, rhs.inner) };
+    }
+
+    #[cfg(not(target_feature = "avx2"))]
+    fn bitand_assign(&mut self, rhs: Self) {
+        for i in 0..8 {
+            self.inner[i] &= rhs.inner[i];
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct BitVector {
-    pub blocks: Vec<__m256i>,
+    pub blocks: Vec<BitBlock>,
 }
 
 impl BitVector {
@@ -11,27 +105,27 @@ impl BitVector {
     const LANE_SIZE: usize = 32;
     const BLOCK_SIZE: usize = 256;
 
-    pub unsafe fn new(nb_bits: usize) -> Self {
+    pub fn new(nb_bits: usize) -> Self {
         BitVector {
             blocks: BitVector::init_blocks(nb_bits),
         }
     }
 
-    pub unsafe fn new_block_size(nb_blocks: usize) -> Self {
+    pub fn new_block_size(nb_blocks: usize) -> Self {
         BitVector {
             blocks: BitVector::init_blocks(nb_blocks * BitVector::BLOCK_SIZE - 1),
         }
     }
 
-    pub unsafe fn from_integer_vec(vec: Vec<i128>) -> Self {
+    pub fn from_integer_vec(vec: Vec<i128>) -> Self {
         let mut bv = BitVector::new(vec.len() * 128 - 1);
-        let mut arr: [i32; BitVector::LANES] = [0; BitVector::LANES];
+        let mut arr = BitLanes([0; BitVector::LANES]);
         let mut block_index = 0;
         let mut index = 0;
         for v in vec {
             let mut val = v.clone();
             for i in 0..4 {
-                arr[index] = val as u32 as i32;
+                arr.0[index] = val as u32 as i32;
                 index += 1;
                 if i < 3 {
                     val = val >> 32;
@@ -39,21 +133,21 @@ impl BitVector {
             }
             if index == 8 {
                 index = 0;
-                bv.blocks[block_index] = _mm256_load_epi32(arr.as_ptr());
+                bv.blocks[block_index] = BitBlock::load(&arr);
                 block_index += 1;
-                arr = [0; BitVector::LANES];
+                arr = BitLanes([0; BitVector::LANES]);
             }
         }
         if index > 0 {
-            bv.blocks[block_index] = _mm256_load_epi32(arr.as_ptr());
+            bv.blocks[block_index] = BitBlock::load(&arr);
         }
         bv
     }
 
-    unsafe fn init_blocks(nb_bits: usize) -> Vec<__m256i> {
-        let mut vec: Vec<__m256i> = Vec::with_capacity(nb_bits / BitVector::BLOCK_SIZE + 1);
+    fn init_blocks(nb_bits: usize) -> Vec<BitBlock> {
+        let mut vec: Vec<BitBlock> = Vec::with_capacity(nb_bits / BitVector::BLOCK_SIZE + 1);
         for _ in 0..vec.capacity() {
-            vec.push(_mm256_setzero_si256());
+            vec.push(BitBlock::zero());
         }
         vec
     }
@@ -62,18 +156,17 @@ impl BitVector {
         self.blocks.len() * BitVector::BLOCK_SIZE
     }
 
-    #[target_feature(enable = "avx2")]
-    pub unsafe fn xor_bit(&mut self, mut bit: usize) {
+    pub fn xor_bit(&mut self, mut bit: usize) {
         let block_index = bit / BitVector::BLOCK_SIZE;
         bit = bit % BitVector::BLOCK_SIZE;
         let lane_index = bit / BitVector::LANE_SIZE;
         bit = bit % BitVector::LANE_SIZE;
-        let mut arr: [i32; BitVector::LANES] = [0; BitVector::LANES];
-        arr[lane_index] ^= 1 << bit;
-        self.blocks[block_index] = xor_256(_mm256_load_epi32(arr.as_ptr()), self.blocks[block_index]);
+        let mut arr = BitLanes([0; BitVector::LANES]);
+        arr.0[lane_index] ^= 1 << bit;
+        self.blocks[block_index] ^= BitBlock::load(&arr);
     }
 
-    pub unsafe fn get(&self, mut bit: usize) -> bool {
+    pub fn get(&self, mut bit: usize) -> bool {
         let block_index = bit / BitVector::BLOCK_SIZE;
         bit = bit % BitVector::BLOCK_SIZE;
         let lane_index = bit / 32;
@@ -81,7 +174,7 @@ impl BitVector {
         self.extract_block(block_index)[lane_index] & (1 << bit) != 0
     }
 
-    pub unsafe fn get_first_one(&self) -> usize {
+    pub fn get_first_one(&self) -> usize {
         for i in 0..self.blocks.len() {
             let block = self.extract_block(i);
             for j in 0..8 {
@@ -93,7 +186,7 @@ impl BitVector {
         0
     }
 
-    pub unsafe fn get_all_ones(&self, nb_bits: usize) -> Vec<usize> {
+    pub fn get_all_ones(&self, nb_bits: usize) -> Vec<usize> {
         let mut index = 0;
         let mut vec = Vec::new();
         for i in 0..self.blocks.len() {
@@ -109,36 +202,32 @@ impl BitVector {
         vec
     }
 
-    #[target_feature(enable = "avx2")]
-    pub unsafe fn xor(&mut self, bv: &BitVector) {
+    pub fn xor(&mut self, bv: &BitVector) {
         for i in 0..self.blocks.len() {
-            self.blocks[i] = xor_256(self.blocks[i], bv.blocks[i]);
+            self.blocks[i] ^= bv.blocks[i];
         }
     }
 
-    #[target_feature(enable = "avx2")]
-    pub unsafe fn and(&mut self, bv: &BitVector) {
+    pub fn and(&mut self, bv: &BitVector) {
         for i in 0..self.blocks.len() {
-            self.blocks[i] = and_256(self.blocks[i], bv.blocks[i]);
+            self.blocks[i] &= bv.blocks[i];
         }
     }
 
-    #[target_feature(enable = "avx2")]
-    pub unsafe fn negate(&mut self) {
+    pub fn negate(&mut self) {
         let a: i32 = !0;
         for i in 0..self.blocks.len() {
-            self.blocks[i] = xor_256(self.blocks[i], _mm256_set1_epi32(a));
+            self.blocks[i] ^= BitBlock::constant(a);
         }
     }
-
-    #[target_feature(enable = "avx2")]
-    pub unsafe fn extend_vec(&mut self, vec: Vec<bool>, nb_bits: usize) {
+    
+    pub fn extend_vec(&mut self, vec: Vec<bool>, nb_bits: usize) {
         let mut bit = nb_bits;
         let mut block_index = bit / BitVector::BLOCK_SIZE;
         bit = bit % BitVector::BLOCK_SIZE;
         let mut lane_index = bit / BitVector::LANE_SIZE;
         bit = bit % BitVector::LANE_SIZE;
-        let mut arr: [i32; BitVector::LANES] = [0; BitVector::LANES];
+        let mut arr = BitLanes([0; BitVector::LANES]);
 
         for val in vec {
             if bit == BitVector::LANE_SIZE {
@@ -146,21 +235,21 @@ impl BitVector {
                 lane_index += 1;
                 if lane_index == BitVector::LANES {
                     lane_index = 0;
-                    self.blocks[block_index] = xor_256(_mm256_load_epi32(arr.as_ptr()), self.blocks[block_index]);
+                    self.blocks[block_index] ^= BitBlock::load(&arr);
                     block_index += 1;
-                    self.blocks.push(_mm256_setzero_si256());
-                    arr = [0; BitVector::LANES];
+                    self.blocks.push(BitBlock::zero());
+                    arr = BitLanes([0; BitVector::LANES]);
                 }
             }
             if val {
-                arr[lane_index] ^= 1 << bit;
+                arr.0[lane_index] ^= 1 << bit;
             }
             bit += 1;
         }
-        self.blocks[block_index] = xor_256(_mm256_load_epi32(arr.as_ptr()), self.blocks[block_index]);
+        self.blocks[block_index] ^= BitBlock::load(&arr);
     }
 
-    pub unsafe fn get_boolean_vec(&self) -> Vec<bool> {
+    pub fn get_boolean_vec(&self) -> Vec<bool> {
         let mut vec: Vec<bool> = Vec::with_capacity(self.blocks.len() * BitVector::BLOCK_SIZE);
         for block_index in 0..self.blocks.len() {
             let arr = self.extract_block(block_index);
@@ -173,7 +262,7 @@ impl BitVector {
         vec
     }
 
-    pub unsafe fn get_integer_vec(&self) -> Vec<i128> {
+    pub fn get_integer_vec(&self) -> Vec<i128> {
         let mut vec: Vec<i128> = Vec::with_capacity(self.blocks.len() * 2);
         for block_index in 0..self.blocks.len() {
             let arr = self.extract_block(block_index);
@@ -188,23 +277,18 @@ impl BitVector {
         vec
     }
 
-    #[target_feature(enable = "avx2")]
-    pub unsafe fn popcount(&self) -> i32 {
+    pub fn popcount(&self) -> i32 {
         let mut sum: i32 = 0;
         for block_index in 0..self.blocks.len() {
             let arr = self.extract_block(block_index);
             for j in 0..8 {
-                sum += _popcnt32(arr[j]);
+                sum += arr[j].count_ones() as i32;
             }
         }
         sum
     }
 
-    #[target_feature(enable = "avx2")]
-    unsafe fn extract_block(&self, index: usize) -> [i32; 8] {
-        [_mm256_extract_epi32::<0>(self.blocks[index]), _mm256_extract_epi32::<1>(self.blocks[index]),
-        _mm256_extract_epi32::<2>(self.blocks[index]), _mm256_extract_epi32::<3>(self.blocks[index]),
-        _mm256_extract_epi32::<4>(self.blocks[index]), _mm256_extract_epi32::<5>(self.blocks[index]),
-        _mm256_extract_epi32::<6>(self.blocks[index]), _mm256_extract_epi32::<7>(self.blocks[index])]
+    fn extract_block(&self, block: usize) -> [i32; 8] {
+        self.blocks[block].extract()
     }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -208,7 +208,7 @@ impl Circuit {
         c_out
     }
 
-    pub  fn t_opt(&self, optimizer: String) -> Circuit {
+    pub fn t_opt(&self, optimizer: String) -> Circuit {
         SlicedCircuit::from_circ(self).t_opt(optimizer)
     }
 }
@@ -223,7 +223,7 @@ pub struct SlicedCircuit {
 }
 
 impl SlicedCircuit {
-    pub  fn new(nb_qubits: usize) -> Self {
+    pub fn new(nb_qubits: usize) -> Self {
         SlicedCircuit {
             nb_qubits: nb_qubits,
             init_circuit: Circuit::new(nb_qubits),
@@ -232,7 +232,7 @@ impl SlicedCircuit {
         }
     }
 
-    pub  fn from_circ(c: &Circuit) -> SlicedCircuit {
+    pub fn from_circ(c: &Circuit) -> SlicedCircuit {
         let mut sliced_c = SlicedCircuit::new(c.nb_qubits);
         sliced_c.init_circuit.ancillas = c.ancillas.clone();
         let mut first_t = 0;
@@ -280,7 +280,7 @@ impl SlicedCircuit {
         sliced_c
     }
 
-    pub  fn t_opt(&mut self, optimizer: String) -> Circuit {
+    pub fn t_opt(&mut self, optimizer: String) -> Circuit {
         let mut c = self.init_circuit.clone();
         for i in 0..self.phase_polynomials.len() {
             let table = self.phase_polynomials[i].table.clone();

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -208,7 +208,7 @@ impl Circuit {
         c_out
     }
 
-    pub unsafe fn t_opt(&self, optimizer: String) -> Circuit {
+    pub  fn t_opt(&self, optimizer: String) -> Circuit {
         SlicedCircuit::from_circ(self).t_opt(optimizer)
     }
 }
@@ -223,7 +223,7 @@ pub struct SlicedCircuit {
 }
 
 impl SlicedCircuit {
-    pub unsafe fn new(nb_qubits: usize) -> Self {
+    pub  fn new(nb_qubits: usize) -> Self {
         SlicedCircuit {
             nb_qubits: nb_qubits,
             init_circuit: Circuit::new(nb_qubits),
@@ -232,7 +232,7 @@ impl SlicedCircuit {
         }
     }
 
-    pub unsafe fn from_circ(c: &Circuit) -> SlicedCircuit {
+    pub  fn from_circ(c: &Circuit) -> SlicedCircuit {
         let mut sliced_c = SlicedCircuit::new(c.nb_qubits);
         sliced_c.init_circuit.ancillas = c.ancillas.clone();
         let mut first_t = 0;
@@ -280,7 +280,7 @@ impl SlicedCircuit {
         sliced_c
     }
 
-    pub unsafe fn t_opt(&mut self, optimizer: String) -> Circuit {
+    pub  fn t_opt(&mut self, optimizer: String) -> Circuit {
         let mut c = self.init_circuit.clone();
         for i in 0..self.phase_polynomials.len() {
             let table = self.phase_polynomials[i].table.clone();

--- a/src/h_opt.rs
+++ b/src/h_opt.rs
@@ -113,7 +113,7 @@ use crate::circuit::Circuit;
     tab
 }
 
-pub  fn internal_h_opt(c_in: &Circuit) -> Circuit {
+pub fn internal_h_opt(c_in: &Circuit) -> Circuit {
     let mut tab = h_opt_reverse(c_in);
     let mut c = tab.to_circ(false);
     for (gate, q) in &c_in.circ {

--- a/src/h_opt.rs
+++ b/src/h_opt.rs
@@ -2,7 +2,7 @@ use crate::pauli_product::PauliProduct;
 use crate::tableau::Tableau;
 use crate::circuit::Circuit;
 
-unsafe fn implement_pauli_z_rotation_from_pauli_product(tab: &mut Tableau, p: &PauliProduct) -> Circuit {
+ fn implement_pauli_z_rotation_from_pauli_product(tab: &mut Tableau, p: &PauliProduct) -> Circuit {
     let mut c = Circuit::new(tab.nb_qubits);
     let mut cnot_circ = Circuit::new(tab.nb_qubits);
     let pivot = p.z.get_first_one();
@@ -21,7 +21,7 @@ unsafe fn implement_pauli_z_rotation_from_pauli_product(tab: &mut Tableau, p: &P
     c
 }
 
-unsafe fn implement_pauli_z_rotation(tab: &mut Tableau, col: usize) -> Circuit {
+ fn implement_pauli_z_rotation(tab: &mut Tableau, col: usize) -> Circuit {
     let pivot = tab.z.iter().position(|z| z.get(col)).unwrap();
     let mut c = Circuit::new(tab.nb_qubits);
     let mut cnot_circ = Circuit::new(tab.nb_qubits);
@@ -40,7 +40,7 @@ unsafe fn implement_pauli_z_rotation(tab: &mut Tableau, col: usize) -> Circuit {
     c
 }
 
-unsafe fn implement_pauli_rotation(tab: &mut Tableau, col: usize) -> Circuit {
+ fn implement_pauli_rotation(tab: &mut Tableau, col: usize) -> Circuit {
     let mut c = Circuit::new(tab.nb_qubits);
     if let Some(pivot) = tab.x.iter().position(|x| x.get(col)) {
         for j in 0..tab.nb_qubits {
@@ -61,7 +61,7 @@ unsafe fn implement_pauli_rotation(tab: &mut Tableau, col: usize) -> Circuit {
 }
 
 
-unsafe fn implement_tof(tab: &mut Tableau, cols: Vec::<usize>, h_gate: bool) -> Circuit {
+ fn implement_tof(tab: &mut Tableau, cols: Vec::<usize>, h_gate: bool) -> Circuit {
     let mut c = Circuit::new(tab.nb_qubits);
     c.append(implement_pauli_rotation(tab, cols[0]).circ);
     c.append(implement_pauli_rotation(tab, cols[1]).circ);
@@ -84,7 +84,7 @@ unsafe fn implement_tof(tab: &mut Tableau, cols: Vec::<usize>, h_gate: bool) -> 
     c
 }
 
-unsafe fn h_opt_reverse(c_in: &Circuit) -> Tableau{
+ fn h_opt_reverse(c_in: &Circuit) -> Tableau{
     let mut tab = Tableau::new(c_in.nb_qubits);
     for (gate, q) in &c_in.circ {
         match &gate[..] {
@@ -113,7 +113,7 @@ unsafe fn h_opt_reverse(c_in: &Circuit) -> Tableau{
     tab
 }
 
-pub unsafe fn internal_h_opt(c_in: &Circuit) -> Circuit {
+pub  fn internal_h_opt(c_in: &Circuit) -> Circuit {
     let mut tab = h_opt_reverse(c_in);
     let mut c = tab.to_circ(false);
     for (gate, q) in &c_in.circ {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod circuit;
+pub mod pauli_product;
+pub mod phase_polynomial;
+pub mod tableau;
+pub mod bit_vector;
+pub mod h_opt;
+pub mod t_merge;
+pub mod t_opt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(stdsimd)]
 mod circuit;
 mod pauli_product;
 mod phase_polynomial;
@@ -47,7 +46,7 @@ fn main() {
     let output_filename = &("circuits/outputs/".to_string() + &filename);
     let (mut c, header, qubits_mapping) = Circuit::from_qc(&args[file_index.unwrap()]);
     println!("File {} processed\n", filename);
-    unsafe {
+     {
         if do_bb_merge { println!("Running BBMerge algorithm"); c = bb_merge(c); }
         if do_fast_t_merge { println!("Running FastTMerge algorithm"); c = fast_t_merge(c); }
         if do_internal_h_opt { println!("Running InternalHOpt algorithm"); c = internal_h_opt(&c); }

--- a/src/pauli_product.rs
+++ b/src/pauli_product.rs
@@ -16,7 +16,7 @@ impl PauliProduct {
         }
     }
 
-    pub  fn is_commuting(&self, p: &PauliProduct) -> bool {
+    pub fn is_commuting(&self, p: &PauliProduct) -> bool {
         let mut x1z2 = self.z.clone();
         x1z2.and(&p.x);
         let mut ac = self.x.clone();
@@ -25,7 +25,7 @@ impl PauliProduct {
         ac.popcount() % 2 == 0
     }
 
-    pub  fn get_boolean_vec(&self, nb_qubits: usize) -> Vec<bool> {
+    pub fn get_boolean_vec(&self, nb_qubits: usize) -> Vec<bool> {
         let mut vec_z = self.z.get_boolean_vec();
         let mut vec_x = self.x.get_boolean_vec();
         vec_z.truncate(nb_qubits);
@@ -34,7 +34,7 @@ impl PauliProduct {
         vec_z
     }
 
-    pub  fn pauli_product_mult(&mut self, p: &PauliProduct) {
+    pub fn pauli_product_mult(&mut self, p: &PauliProduct) {
         let mut x1z2 = self.z.clone();
         x1z2.and(&p.x);
         let mut ac = self.x.clone();

--- a/src/pauli_product.rs
+++ b/src/pauli_product.rs
@@ -16,7 +16,7 @@ impl PauliProduct {
         }
     }
 
-    pub unsafe fn is_commuting(&self, p: &PauliProduct) -> bool {
+    pub  fn is_commuting(&self, p: &PauliProduct) -> bool {
         let mut x1z2 = self.z.clone();
         x1z2.and(&p.x);
         let mut ac = self.x.clone();
@@ -25,7 +25,7 @@ impl PauliProduct {
         ac.popcount() % 2 == 0
     }
 
-    pub unsafe fn get_boolean_vec(&self, nb_qubits: usize) -> Vec<bool> {
+    pub  fn get_boolean_vec(&self, nb_qubits: usize) -> Vec<bool> {
         let mut vec_z = self.z.get_boolean_vec();
         let mut vec_x = self.x.get_boolean_vec();
         vec_z.truncate(nb_qubits);
@@ -34,7 +34,7 @@ impl PauliProduct {
         vec_z
     }
 
-    pub unsafe fn pauli_product_mult(&mut self, p: &PauliProduct) {
+    pub  fn pauli_product_mult(&mut self, p: &PauliProduct) {
         let mut x1z2 = self.z.clone();
         x1z2.and(&p.x);
         let mut ac = self.x.clone();

--- a/src/phase_polynomial.rs
+++ b/src/phase_polynomial.rs
@@ -9,14 +9,14 @@ pub struct PhasePolynomial {
 }
 
 impl PhasePolynomial {
-    pub  fn new(nb_qubits: usize) -> Self {
+    pub fn new(nb_qubits: usize) -> Self {
         PhasePolynomial {
             nb_qubits: nb_qubits,
             table: Vec::new(),
         }
     }
 
-    pub  fn clifford_correction(&self, table: &Vec<BitVector>, nb_qubits: usize) -> Tableau {
+    pub fn clifford_correction(&self, table: &Vec<BitVector>, nb_qubits: usize) -> Tableau {
         let mut tab = Tableau::new(nb_qubits);
         for i in 0..nb_qubits {
             for j in (i+1)..nb_qubits {
@@ -35,7 +35,7 @@ impl PhasePolynomial {
         tab
     }
 
-    pub  fn to_circ(&self) -> Circuit {
+    pub fn to_circ(&self) -> Circuit {
         let mut c = Circuit::new(self.nb_qubits);
         for z in &self.table {
             let mut cnot_circ = Circuit::new(self.nb_qubits);

--- a/src/phase_polynomial.rs
+++ b/src/phase_polynomial.rs
@@ -9,14 +9,14 @@ pub struct PhasePolynomial {
 }
 
 impl PhasePolynomial {
-    pub unsafe fn new(nb_qubits: usize) -> Self {
+    pub  fn new(nb_qubits: usize) -> Self {
         PhasePolynomial {
             nb_qubits: nb_qubits,
             table: Vec::new(),
         }
     }
 
-    pub unsafe fn clifford_correction(&self, table: &Vec<BitVector>, nb_qubits: usize) -> Tableau {
+    pub  fn clifford_correction(&self, table: &Vec<BitVector>, nb_qubits: usize) -> Tableau {
         let mut tab = Tableau::new(nb_qubits);
         for i in 0..nb_qubits {
             for j in (i+1)..nb_qubits {
@@ -35,7 +35,7 @@ impl PhasePolynomial {
         tab
     }
 
-    pub unsafe fn to_circ(&self) -> Circuit {
+    pub  fn to_circ(&self) -> Circuit {
         let mut c = Circuit::new(self.nb_qubits);
         for z in &self.table {
             let mut cnot_circ = Circuit::new(self.nb_qubits);

--- a/src/t_merge.rs
+++ b/src/t_merge.rs
@@ -2,7 +2,7 @@ use crate::tableau::{Tableau, TableauColumnMajor};
 use crate::circuit::Circuit;
 use std::collections::HashMap;
 
-pub  fn bb_merge(c_in: Circuit) -> Circuit {
+pub fn bb_merge(c_in: Circuit) -> Circuit {
     let nb_qubits = c_in.nb_qubits;
     let v = rank_vector(&c_in);
     let mut r = vec![1; v.len()];
@@ -63,7 +63,7 @@ pub  fn bb_merge(c_in: Circuit) -> Circuit {
     c
 }
 
-pub  fn fast_t_merge(c_in: Circuit) -> Circuit {
+pub fn fast_t_merge(c_in: Circuit) -> Circuit {
     let nb_qubits = c_in.nb_qubits;
     let v = rank_vector(&c_in);
     let mut w = v.clone();
@@ -197,7 +197,7 @@ pub  fn fast_t_merge(c_in: Circuit) -> Circuit {
     tab
 }
 
-pub  fn rank_vector(c_in: &Circuit) -> Vec::<bool> {
+pub fn rank_vector(c_in: &Circuit) -> Vec::<bool> {
     let mut tab = reverse_diagonalization(c_in);
     let mut vec = Vec::new();
     for (gate, q) in &c_in.circ {

--- a/src/t_merge.rs
+++ b/src/t_merge.rs
@@ -2,7 +2,7 @@ use crate::tableau::{Tableau, TableauColumnMajor};
 use crate::circuit::Circuit;
 use std::collections::HashMap;
 
-pub unsafe fn bb_merge(c_in: Circuit) -> Circuit {
+pub  fn bb_merge(c_in: Circuit) -> Circuit {
     let nb_qubits = c_in.nb_qubits;
     let v = rank_vector(&c_in);
     let mut r = vec![1; v.len()];
@@ -63,7 +63,7 @@ pub unsafe fn bb_merge(c_in: Circuit) -> Circuit {
     c
 }
 
-pub unsafe fn fast_t_merge(c_in: Circuit) -> Circuit {
+pub  fn fast_t_merge(c_in: Circuit) -> Circuit {
     let nb_qubits = c_in.nb_qubits;
     let v = rank_vector(&c_in);
     let mut w = v.clone();
@@ -141,7 +141,7 @@ pub unsafe fn fast_t_merge(c_in: Circuit) -> Circuit {
     c
 }
 
-unsafe fn diagonalize_pauli_rotation(tab: &mut Tableau, col: usize) -> bool {
+ fn diagonalize_pauli_rotation(tab: &mut Tableau, col: usize) -> bool {
     if let Some(pivot) = tab.x.iter().position(|x| x.get(col)) {
         for j in 0..tab.nb_qubits {
             if tab.x[j].get(col) && j != pivot {
@@ -157,7 +157,7 @@ unsafe fn diagonalize_pauli_rotation(tab: &mut Tableau, col: usize) -> bool {
     false
 }
 
-unsafe fn diagonalize_tof(tab: &mut Tableau, cols: Vec::<usize>, h_gate: bool) -> Vec::<bool> {
+ fn diagonalize_tof(tab: &mut Tableau, cols: Vec::<usize>, h_gate: bool) -> Vec::<bool> {
     let mut vec = Vec::new();
     vec.push(diagonalize_pauli_rotation(tab, cols[0]));
     vec.push(diagonalize_pauli_rotation(tab, cols[1]));
@@ -168,7 +168,7 @@ unsafe fn diagonalize_tof(tab: &mut Tableau, cols: Vec::<usize>, h_gate: bool) -
     vec
 }
 
-unsafe fn reverse_diagonalization(c_in: &Circuit) -> Tableau {
+ fn reverse_diagonalization(c_in: &Circuit) -> Tableau {
     let mut tab = Tableau::new(c_in.nb_qubits);
     for (gate, q) in &c_in.circ {
         match &gate[..] {
@@ -197,7 +197,7 @@ unsafe fn reverse_diagonalization(c_in: &Circuit) -> Tableau {
     tab
 }
 
-pub unsafe fn rank_vector(c_in: &Circuit) -> Vec::<bool> {
+pub  fn rank_vector(c_in: &Circuit) -> Vec::<bool> {
     let mut tab = reverse_diagonalization(c_in);
     let mut vec = Vec::new();
     for (gate, q) in &c_in.circ {

--- a/src/t_opt.rs
+++ b/src/t_opt.rs
@@ -1,7 +1,7 @@
 use crate::bit_vector::BitVector;
 use hashbrown::HashMap;
 
-pub  fn proper(mut table: Vec<BitVector>) -> Vec<BitVector> {
+pub fn proper(mut table: Vec<BitVector>) -> Vec<BitVector> {
     let mut map = HashMap::new();
     let mut to_remove: Vec<usize> = Vec::new();
     for i in 0..table.len() {
@@ -25,7 +25,7 @@ pub  fn proper(mut table: Vec<BitVector>) -> Vec<BitVector> {
     table
 }
 
-pub  fn to_remove(table: &Vec<BitVector>) -> Vec<usize> {
+pub fn to_remove(table: &Vec<BitVector>) -> Vec<usize> {
     let mut map = HashMap::new();
     let mut to_remove: Vec<usize> = Vec::new();
     for i in 0..table.len() {
@@ -45,7 +45,7 @@ pub  fn to_remove(table: &Vec<BitVector>) -> Vec<usize> {
     to_remove
 }
 
-pub  fn kernel(matrix: &mut Vec<BitVector>,augmented_matrix: &mut Vec<BitVector>,
+pub fn kernel(matrix: &mut Vec<BitVector>,augmented_matrix: &mut Vec<BitVector>,
                                pivots: &mut HashMap<usize, usize>) -> Option<BitVector> {
     for i in 0..matrix.len() {
         if pivots.contains_key(&i) { continue; }
@@ -76,7 +76,7 @@ pub  fn kernel(matrix: &mut Vec<BitVector>,augmented_matrix: &mut Vec<BitVector>
     None
 }
 
-pub  fn tohpe(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
+pub fn tohpe(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
      fn clear_column(i: usize, matrix: &mut Vec<BitVector>, augmented_matrix: &mut Vec<BitVector>,
                            pivots: &mut HashMap<usize, usize>) {
         if !pivots.contains_key(&i) { return; }
@@ -225,7 +225,7 @@ pub  fn tohpe(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
     table
 }
 
-pub  fn fast_todd(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
+pub fn fast_todd(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
     loop {
     table = tohpe(table.clone(), nb_qubits);
     let mut matrix = table.clone();

--- a/src/t_opt.rs
+++ b/src/t_opt.rs
@@ -1,7 +1,7 @@
 use crate::bit_vector::BitVector;
 use hashbrown::HashMap;
 
-pub unsafe fn proper(mut table: Vec<BitVector>) -> Vec<BitVector> {
+pub  fn proper(mut table: Vec<BitVector>) -> Vec<BitVector> {
     let mut map = HashMap::new();
     let mut to_remove: Vec<usize> = Vec::new();
     for i in 0..table.len() {
@@ -25,7 +25,7 @@ pub unsafe fn proper(mut table: Vec<BitVector>) -> Vec<BitVector> {
     table
 }
 
-pub unsafe fn to_remove(table: &Vec<BitVector>) -> Vec<usize> {
+pub  fn to_remove(table: &Vec<BitVector>) -> Vec<usize> {
     let mut map = HashMap::new();
     let mut to_remove: Vec<usize> = Vec::new();
     for i in 0..table.len() {
@@ -45,7 +45,7 @@ pub unsafe fn to_remove(table: &Vec<BitVector>) -> Vec<usize> {
     to_remove
 }
 
-pub unsafe fn kernel(matrix: &mut Vec<BitVector>,augmented_matrix: &mut Vec<BitVector>,
+pub  fn kernel(matrix: &mut Vec<BitVector>,augmented_matrix: &mut Vec<BitVector>,
                                pivots: &mut HashMap<usize, usize>) -> Option<BitVector> {
     for i in 0..matrix.len() {
         if pivots.contains_key(&i) { continue; }
@@ -76,8 +76,8 @@ pub unsafe fn kernel(matrix: &mut Vec<BitVector>,augmented_matrix: &mut Vec<BitV
     None
 }
 
-pub unsafe fn tohpe(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
-    unsafe fn clear_column(i: usize, matrix: &mut Vec<BitVector>, augmented_matrix: &mut Vec<BitVector>,
+pub  fn tohpe(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
+     fn clear_column(i: usize, matrix: &mut Vec<BitVector>, augmented_matrix: &mut Vec<BitVector>,
                            pivots: &mut HashMap<usize, usize>) {
         if !pivots.contains_key(&i) { return; }
         let val = pivots.remove(&i).unwrap();
@@ -225,7 +225,7 @@ pub unsafe fn tohpe(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVecto
     table
 }
 
-pub unsafe fn fast_todd(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
+pub  fn fast_todd(mut table: Vec<BitVector>, nb_qubits: usize) -> Vec<BitVector> {
     loop {
     table = tohpe(table.clone(), nb_qubits);
     let mut matrix = table.clone();

--- a/src/tableau.rs
+++ b/src/tableau.rs
@@ -11,7 +11,7 @@ pub struct Tableau {
 }
 
 impl Tableau {
-    pub unsafe fn new(nb_qubits: usize) -> Self {
+    pub  fn new(nb_qubits: usize) -> Self {
         Tableau {
             nb_qubits: nb_qubits,
             z: Tableau::init_z(nb_qubits),
@@ -20,7 +20,7 @@ impl Tableau {
         }
     }
 
-    unsafe fn init_z(nb_qubits: usize) -> Vec<BitVector> {
+     fn init_z(nb_qubits: usize) -> Vec<BitVector> {
         let mut vec = Vec::new();
         for i in 0..nb_qubits {
             let mut bv = BitVector::new(nb_qubits << 1);
@@ -30,7 +30,7 @@ impl Tableau {
         vec
     }
 
-    unsafe fn init_x(nb_qubits: usize) -> Vec<BitVector> {
+     fn init_x(nb_qubits: usize) -> Vec<BitVector> {
         let mut vec = Vec::new();
         for i in 0..nb_qubits {
             let mut bv = BitVector::new(nb_qubits << 1);
@@ -40,15 +40,15 @@ impl Tableau {
         vec
     }
 
-    pub unsafe fn append_x(&mut self, qubit: usize) {
+    pub  fn append_x(&mut self, qubit: usize) {
         self.signs.xor(&self.z[qubit]);
     }
 
-    pub unsafe fn append_z(&mut self, qubit: usize) {
+    pub  fn append_z(&mut self, qubit: usize) {
         self.signs.xor(&self.x[qubit]);
     }
 
-    pub unsafe fn append_v(&mut self, qubit: usize) {
+    pub  fn append_v(&mut self, qubit: usize) {
         let mut a = self.x[qubit].clone();
         a.negate();
         a.and(&self.z[qubit]);
@@ -56,20 +56,20 @@ impl Tableau {
         self.x[qubit].xor(&self.z[qubit]);
     }
 
-    pub unsafe fn append_s(&mut self, qubit: usize) {
+    pub  fn append_s(&mut self, qubit: usize) {
         let mut a = self.z[qubit].clone();
         a.and(&self.x[qubit]);
         self.signs.xor(&a);
         self.z[qubit].xor(&self.x[qubit]);
     }
 
-    pub unsafe fn append_h(&mut self, qubit: usize) {
+    pub  fn append_h(&mut self, qubit: usize) {
         self.append_s(qubit);
         self.append_v(qubit);
         self.append_s(qubit);
     }
 
-    pub unsafe fn append_cx(&mut self, qubits: Vec<usize>) {
+    pub  fn append_cx(&mut self, qubits: Vec<usize>) {
         let mut a =  self.z[qubits[0]].clone();
         a.negate();
         a.xor(&self.x[qubits[1]]);
@@ -82,7 +82,7 @@ impl Tableau {
         self.x[qubits[1]].xor(&a);
     }
 
-    pub unsafe fn append_cz(&mut self, qubits: Vec<usize>) {
+    pub  fn append_cz(&mut self, qubits: Vec<usize>) {
         self.append_s(qubits[0]);
         self.append_s(qubits[1]);
         self.append_cx(qubits.to_vec());
@@ -91,7 +91,7 @@ impl Tableau {
         self.append_cx(qubits);
     }
 
-    pub unsafe fn extract_pauli_product(&self, col: usize) -> PauliProduct {
+    pub  fn extract_pauli_product(&self, col: usize) -> PauliProduct {
         let mut z = BitVector::new(self.nb_qubits);
         let mut x = BitVector::new(self.nb_qubits);
         for i in 0..self.nb_qubits {
@@ -101,7 +101,7 @@ impl Tableau {
         PauliProduct::new(z, x, self.signs.get(col))
     }
 
-    pub unsafe fn insert_pauli_product(&mut self, p: PauliProduct, col: usize) {
+    pub  fn insert_pauli_product(&mut self, p: PauliProduct, col: usize) {
         let p_x = p.x.get_boolean_vec();
         let p_z = p.z.get_boolean_vec();
         for i in 0..self.nb_qubits {
@@ -117,29 +117,29 @@ impl Tableau {
         }
     }
 
-    pub unsafe fn prepend_x(&mut self, qubit: usize) {
+    pub  fn prepend_x(&mut self, qubit: usize) {
         self.signs.xor_bit(qubit);
     }
 
-    pub unsafe fn prepend_z(&mut self, qubit: usize) {
+    pub  fn prepend_z(&mut self, qubit: usize) {
         self.signs.xor_bit(qubit + self.nb_qubits);
     }
 
-    pub unsafe fn prepend_s(&mut self, qubit: usize) {
+    pub  fn prepend_s(&mut self, qubit: usize) {
         let stab = self.extract_pauli_product(qubit);
         let mut destab = self.extract_pauli_product(qubit + self.nb_qubits);
         destab.pauli_product_mult(&stab);
         self.insert_pauli_product(destab, qubit + self.nb_qubits);
     }
 
-    pub unsafe fn prepend_h(&mut self, qubit: usize) {
+    pub  fn prepend_h(&mut self, qubit: usize) {
         let stab = self.extract_pauli_product(qubit);
         let destab = self.extract_pauli_product(qubit + self.nb_qubits);
         self.insert_pauli_product(destab, qubit);
         self.insert_pauli_product(stab, qubit + self.nb_qubits);
     }
 
-    pub unsafe fn prepend_cx(&mut self, qubits: Vec<usize>) {
+    pub  fn prepend_cx(&mut self, qubits: Vec<usize>) {
         let stab_ctrl = self.extract_pauli_product(qubits[0]);
         let mut stab_targ = self.extract_pauli_product(qubits[1]);
         let mut destab_ctrl = self.extract_pauli_product(qubits[0] + self.nb_qubits);
@@ -150,7 +150,7 @@ impl Tableau {
         self.insert_pauli_product(destab_ctrl, qubits[0] + self.nb_qubits);
     }
 
-    pub unsafe fn to_circ(&self, inverse: bool) -> Circuit {
+    pub  fn to_circ(&self, inverse: bool) -> Circuit {
         let mut tab = self.clone();
         let mut c = Circuit::new(self.nb_qubits);
         for i in 0..self.nb_qubits {
@@ -228,7 +228,7 @@ pub struct TableauColumnMajor {
 }
 
 impl TableauColumnMajor {
-    pub unsafe fn new(nb_qubits: usize) -> Self {
+    pub  fn new(nb_qubits: usize) -> Self {
         TableauColumnMajor {
             nb_qubits: nb_qubits,
             stabs: TableauColumnMajor::init_stabs(nb_qubits),
@@ -236,7 +236,7 @@ impl TableauColumnMajor {
         }
     }
 
-    unsafe fn init_stabs(nb_qubits: usize) -> Vec<PauliProduct> {
+     fn init_stabs(nb_qubits: usize) -> Vec<PauliProduct> {
         let mut vec = Vec::new();
         for i in 0..nb_qubits {
             let mut bv = BitVector::new(nb_qubits);
@@ -246,7 +246,7 @@ impl TableauColumnMajor {
         vec
     }
 
-    unsafe fn init_destabs(nb_qubits: usize) -> Vec<PauliProduct> {
+     fn init_destabs(nb_qubits: usize) -> Vec<PauliProduct> {
         let mut vec = Vec::new();
         for i in 0..nb_qubits {
             let mut bv = BitVector::new(nb_qubits);
@@ -264,28 +264,28 @@ impl TableauColumnMajor {
         self.destabs[qubit].sign ^= true;
     }
 
-    pub unsafe fn prepend_v(&mut self, qubit: usize) {
+    pub  fn prepend_v(&mut self, qubit: usize) {
         self.stabs[qubit].pauli_product_mult(&self.destabs[qubit]);
     }
 
-    pub unsafe fn prepend_s(&mut self, qubit: usize) {
+    pub  fn prepend_s(&mut self, qubit: usize) {
         self.destabs[qubit].pauli_product_mult(&self.stabs[qubit]);
     }
 
-    pub unsafe fn prepend_h(&mut self, qubit: usize) {
+    pub  fn prepend_h(&mut self, qubit: usize) {
         self.prepend_s(qubit);
         self.prepend_v(qubit);
         self.prepend_s(qubit);
     }
 
-    pub unsafe fn prepend_cx(&mut self, qubits: Vec<usize>) {
+    pub  fn prepend_cx(&mut self, qubits: Vec<usize>) {
         let p = self.stabs[qubits[0]].clone();
         self.stabs[qubits[1]].pauli_product_mult(&p);
         let p = self.destabs[qubits[1]].clone();
         self.destabs[qubits[0]].pauli_product_mult(&p);
     }
 
-    pub unsafe fn to_circ(&self, inverse: bool) -> Circuit {
+    pub  fn to_circ(&self, inverse: bool) -> Circuit {
         let mut tab = self.clone();
         let mut c = Circuit::new(tab.nb_qubits);
         for i in 0..tab.nb_qubits {

--- a/src/tableau.rs
+++ b/src/tableau.rs
@@ -11,7 +11,7 @@ pub struct Tableau {
 }
 
 impl Tableau {
-    pub  fn new(nb_qubits: usize) -> Self {
+    pub fn new(nb_qubits: usize) -> Self {
         Tableau {
             nb_qubits: nb_qubits,
             z: Tableau::init_z(nb_qubits),
@@ -40,15 +40,15 @@ impl Tableau {
         vec
     }
 
-    pub  fn append_x(&mut self, qubit: usize) {
+    pub fn append_x(&mut self, qubit: usize) {
         self.signs.xor(&self.z[qubit]);
     }
 
-    pub  fn append_z(&mut self, qubit: usize) {
+    pub fn append_z(&mut self, qubit: usize) {
         self.signs.xor(&self.x[qubit]);
     }
 
-    pub  fn append_v(&mut self, qubit: usize) {
+    pub fn append_v(&mut self, qubit: usize) {
         let mut a = self.x[qubit].clone();
         a.negate();
         a.and(&self.z[qubit]);
@@ -56,20 +56,20 @@ impl Tableau {
         self.x[qubit].xor(&self.z[qubit]);
     }
 
-    pub  fn append_s(&mut self, qubit: usize) {
+    pub fn append_s(&mut self, qubit: usize) {
         let mut a = self.z[qubit].clone();
         a.and(&self.x[qubit]);
         self.signs.xor(&a);
         self.z[qubit].xor(&self.x[qubit]);
     }
 
-    pub  fn append_h(&mut self, qubit: usize) {
+    pub fn append_h(&mut self, qubit: usize) {
         self.append_s(qubit);
         self.append_v(qubit);
         self.append_s(qubit);
     }
 
-    pub  fn append_cx(&mut self, qubits: Vec<usize>) {
+    pub fn append_cx(&mut self, qubits: Vec<usize>) {
         let mut a =  self.z[qubits[0]].clone();
         a.negate();
         a.xor(&self.x[qubits[1]]);
@@ -82,7 +82,7 @@ impl Tableau {
         self.x[qubits[1]].xor(&a);
     }
 
-    pub  fn append_cz(&mut self, qubits: Vec<usize>) {
+    pub fn append_cz(&mut self, qubits: Vec<usize>) {
         self.append_s(qubits[0]);
         self.append_s(qubits[1]);
         self.append_cx(qubits.to_vec());
@@ -91,7 +91,7 @@ impl Tableau {
         self.append_cx(qubits);
     }
 
-    pub  fn extract_pauli_product(&self, col: usize) -> PauliProduct {
+    pub fn extract_pauli_product(&self, col: usize) -> PauliProduct {
         let mut z = BitVector::new(self.nb_qubits);
         let mut x = BitVector::new(self.nb_qubits);
         for i in 0..self.nb_qubits {
@@ -101,7 +101,7 @@ impl Tableau {
         PauliProduct::new(z, x, self.signs.get(col))
     }
 
-    pub  fn insert_pauli_product(&mut self, p: PauliProduct, col: usize) {
+    pub fn insert_pauli_product(&mut self, p: PauliProduct, col: usize) {
         let p_x = p.x.get_boolean_vec();
         let p_z = p.z.get_boolean_vec();
         for i in 0..self.nb_qubits {
@@ -117,29 +117,29 @@ impl Tableau {
         }
     }
 
-    pub  fn prepend_x(&mut self, qubit: usize) {
+    pub fn prepend_x(&mut self, qubit: usize) {
         self.signs.xor_bit(qubit);
     }
 
-    pub  fn prepend_z(&mut self, qubit: usize) {
+    pub fn prepend_z(&mut self, qubit: usize) {
         self.signs.xor_bit(qubit + self.nb_qubits);
     }
 
-    pub  fn prepend_s(&mut self, qubit: usize) {
+    pub fn prepend_s(&mut self, qubit: usize) {
         let stab = self.extract_pauli_product(qubit);
         let mut destab = self.extract_pauli_product(qubit + self.nb_qubits);
         destab.pauli_product_mult(&stab);
         self.insert_pauli_product(destab, qubit + self.nb_qubits);
     }
 
-    pub  fn prepend_h(&mut self, qubit: usize) {
+    pub fn prepend_h(&mut self, qubit: usize) {
         let stab = self.extract_pauli_product(qubit);
         let destab = self.extract_pauli_product(qubit + self.nb_qubits);
         self.insert_pauli_product(destab, qubit);
         self.insert_pauli_product(stab, qubit + self.nb_qubits);
     }
 
-    pub  fn prepend_cx(&mut self, qubits: Vec<usize>) {
+    pub fn prepend_cx(&mut self, qubits: Vec<usize>) {
         let stab_ctrl = self.extract_pauli_product(qubits[0]);
         let mut stab_targ = self.extract_pauli_product(qubits[1]);
         let mut destab_ctrl = self.extract_pauli_product(qubits[0] + self.nb_qubits);
@@ -150,7 +150,7 @@ impl Tableau {
         self.insert_pauli_product(destab_ctrl, qubits[0] + self.nb_qubits);
     }
 
-    pub  fn to_circ(&self, inverse: bool) -> Circuit {
+    pub fn to_circ(&self, inverse: bool) -> Circuit {
         let mut tab = self.clone();
         let mut c = Circuit::new(self.nb_qubits);
         for i in 0..self.nb_qubits {
@@ -228,7 +228,7 @@ pub struct TableauColumnMajor {
 }
 
 impl TableauColumnMajor {
-    pub  fn new(nb_qubits: usize) -> Self {
+    pub fn new(nb_qubits: usize) -> Self {
         TableauColumnMajor {
             nb_qubits: nb_qubits,
             stabs: TableauColumnMajor::init_stabs(nb_qubits),
@@ -264,28 +264,28 @@ impl TableauColumnMajor {
         self.destabs[qubit].sign ^= true;
     }
 
-    pub  fn prepend_v(&mut self, qubit: usize) {
+    pub fn prepend_v(&mut self, qubit: usize) {
         self.stabs[qubit].pauli_product_mult(&self.destabs[qubit]);
     }
 
-    pub  fn prepend_s(&mut self, qubit: usize) {
+    pub fn prepend_s(&mut self, qubit: usize) {
         self.destabs[qubit].pauli_product_mult(&self.stabs[qubit]);
     }
 
-    pub  fn prepend_h(&mut self, qubit: usize) {
+    pub fn prepend_h(&mut self, qubit: usize) {
         self.prepend_s(qubit);
         self.prepend_v(qubit);
         self.prepend_s(qubit);
     }
 
-    pub  fn prepend_cx(&mut self, qubits: Vec<usize>) {
+    pub fn prepend_cx(&mut self, qubits: Vec<usize>) {
         let p = self.stabs[qubits[0]].clone();
         self.stabs[qubits[1]].pauli_product_mult(&p);
         let p = self.destabs[qubits[1]].clone();
         self.destabs[qubits[0]].pauli_product_mult(&p);
     }
 
-    pub  fn to_circ(&self, inverse: bool) -> Circuit {
+    pub fn to_circ(&self, inverse: bool) -> Circuit {
         let mut tab = self.clone();
         let mut c = Circuit::new(tab.nb_qubits);
         for i in 0..tab.nb_qubits {


### PR DESCRIPTION
Hi,

This PR modifies `BitVector` so that all SIMD operations (on `__mm256i`) are hidden behind a `BitBlock` struct, and scalar alternatives are provided when AVX2 is not available (e.g on arm-based apple laptops). When AVX2 is enabled, this has the same performance as before (I've checked and the generated assembly code is essentially identical).  I've added a line to the README describing how to enable SIMD, which you can do by setting `RUSTFLAGS="-C target-cpu=native"` when compiling.

I've also removed the usage of the `_mm256_load_epi32` intrinsic since this was unnecessary and is only supported on AVX512 (which is not widely available). Also as a consequence of this, `unsafe` can removed from all functions, and the code can now be build on the stable version of the compiler.

I tried to keep as much the same as possible, but there are some easy changes that could be done if you wanted more performance out of `BitVector` (e.g `BitVector::get_first_one` could use more SIMD). 